### PR TITLE
Fix the irm check when files are replicated

### DIFF
--- a/plugins/check_irods_resource_all.sh
+++ b/plugins/check_irods_resource_all.sh
@@ -169,12 +169,12 @@ else
 fi
 
 if [ ${IRM_RETURN_CODE} -gt ${RETURN_CODE} ]; then
-    RETURN_CODE=${IRM_RETURN_CODE}
     if [ ${RETURN_CODE} -gt ${STATE_OK} ]; then
         RETURN_MESSAGE="${RETURN_MESSAGE}; ERROR: irm metric failed"
     else
         RETURN_MESSAGE="ERROR: irm metric failed"
     fi
+    RETURN_CODE=${IRM_RETURN_CODE}
 fi
 
 echo "[${DATE}] PROCESS_SERVICE_CHECK_RESULT;${HOST};org.irods.irods4.Resource-Irm;${IRM_RETURN_CODE};${IRM_PLUGIN_OUTPUT}" > $NAGIOSCMD

--- a/plugins/check_irods_resource_irm.sh
+++ b/plugins/check_irods_resource_irm.sh
@@ -63,7 +63,7 @@ delete_file() {
     fi
 
     # Check that it exists on the requested resource
-    OUTPUT=`ils -l ${FILE} 2>&1 | awk '{ print $3}' | cut -d';' -f1`
+    OUTPUT=`ils -l ${FILE} 2>&1 | head -1 | awk '{ print $3}' | cut -d';' -f1`
     if [ "x${OUTPUT}" != "x${RESOURCE}" ]; then
         echo "The ${FILE} file does not exist on the requested resource"
         exit ${STATE_CRITICAL}


### PR DESCRIPTION
Fix the check-all message when only irm is failing